### PR TITLE
Adds pruning nothing to fix storekey panic

### DIFF
--- a/uni-5/03_V12_ALPHA_UPGRADE.md
+++ b/uni-5/03_V12_ALPHA_UPGRADE.md
@@ -29,6 +29,8 @@ Edit your Juno node app file config (`$HOME/.juno/config/app.toml`) to be 0 fees
 
 ```toml
 minimum-gas-prices = "0ujunox"
+  and
+pruning = "nothing" 
 ```
 
 ## Setup Feeder


### PR DESCRIPTION
TODO: add install go1.19 requirement

Silk: panic: cannot delete latest saved version (12)
Oni: Jan 20 17:14:59 oni-testnets cosmovisor[1146067]: panic: cannot delete latest saved version (14)

pruning = nothing fixed, but so hacky. Could it be due to everyone using even storekeys?

**If everyone prunes the blocks at even amounts, lets put the upgrade on an uneven/prime block??**
Eventually we run out, but at least it could be a temp work around
